### PR TITLE
[#177416396] Enables exact match for fuzzy search

### DIFF
--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -29,7 +29,8 @@ class Tribute {
     spaceSelectsMatch = false,
     searchOpts = {},
     menuItemLimit = null,
-    menuShowMinLength = 0
+    menuShowMinLength = 0,
+    exactMatch = false
   }) {
     this.autocompleteMode = autocompleteMode;
     this.autocompleteSeparator = autocompleteSeparator;
@@ -43,6 +44,7 @@ class Tribute {
     this.positionMenu = positionMenu;
     this.hasTrailingSpace = false;
     this.spaceSelectsMatch = spaceSelectsMatch;
+    this.exactMatch = exactMatch;
 
     if (this.autocompleteMode) {
       trigger = "";

--- a/src/TributeSearch.js
+++ b/src/TributeSearch.js
@@ -68,10 +68,11 @@ class TributeSearch {
         let best, temp
 
         while (index > -1) {
-            patternCache.push(index)
-            temp = this.traverse(string, pattern, index + 1, patternIndex + 1, patternCache)
-            patternCache.pop()
-
+            if (this.continueTraversal(patternCache, index)) {
+              patternCache.push(index)
+              temp = this.traverse(string, pattern, index + 1, patternIndex + 1, patternCache)
+              patternCache.pop()
+            }
             // if downstream traversal failed, return best answer so far
             if (!temp) {
                 return best
@@ -116,6 +117,16 @@ class TributeSearch {
         })
 
         return rendered
+    }
+
+    continueTraversal(patternCache, index) {
+      if (!this.tribute.exactMatch || patternCache.length < 1) {
+        return true;
+      }
+      if (this.tribute.exactMatch && patternCache[patternCache.length -1] + 1 === index) {
+        return true;
+      }
+      return false;
     }
 
     filter(pattern, arr, opts) {

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -798,3 +798,40 @@ describe("Tribute loadingItemTemplate", function() {
     });
   });
 });
+
+describe("When Tribute.exactMatch is true", function() {
+  afterEach(function() {
+    clearDom();
+  });
+
+  it("should only return items that match input exactly", () => {
+    let input = createDomElement();
+
+    let collectionObject = {
+      exactMatch: true,
+      values: [
+        {
+          key: "abcd",
+          value: "abcdefg",
+          email: "abcdefg@zurb.com"
+        },
+        {
+          key: "axbxcxd",
+          value: "axbxcxd",
+          email: "axbxcxd@zurb.com"
+        }
+      ]
+    };
+
+    let tribute = attachTribute(collectionObject, input.id);
+    fillIn(input, "@abc");
+
+    const popupList = document.querySelectorAll(".tribute-container > ul > li");
+    expect(popupList.length).toBe(1);
+
+    let containerDiv = document.getElementsByClassName("tribute-container")[0];
+    expect(containerDiv.innerText).toBe("abcd");
+
+    detachTribute(tribute, input.id);
+  });
+});


### PR DESCRIPTION
Adds exactMatch key to Tribute, default false, that can be passed to new Tribute()

`new Tribute({exactMatch: true, collection: ... })`

exactMatch disables downstream traversal of lookups that do not match the input pattern exactly.

Example:
_input_ = "bcd"
_values_ = [ "abcde", "axbxcxdxe"]
_returns_ = ["abcde"]

exactMatch set to false (default state / current behavior):
![image](https://user-images.githubusercontent.com/43197720/115691385-ea193400-a355-11eb-9c55-a8afcb77bf79.png)

exactMatch set to true:
![image](https://user-images.githubusercontent.com/43197720/115691163-b1795a80-a355-11eb-8c1e-eaef4759521f.png)
